### PR TITLE
Remove drop from quagga firewall

### DIFF
--- a/templates/quagga.tpl
+++ b/templates/quagga.tpl
@@ -35,7 +35,6 @@ iptables -A FORWARD -i eth0 -p tcp --dport 22 -j ACCEPT
 iptables -A FORWARD -i eth0 -p tcp --dport 5201 -j ACCEPT
 iptables -A FORWARD -i eth0 -p icmp --icmp-type echo-request -j ACCEPT
 iptables -A FORWARD -i eth0 -p icmp --icmp-type echo-reply -j ACCEPT
-iptables -A FORWARD -j DROP
 
 # Save to IPTables file for persistence on reboot
 iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
*What?*
- Remove line that drops packets that aren't allowed in a certain set of ports

*Why?*
- Dropping packets from other ports causes the gatus dashboard to show only approved ports, but the other ports show failure.